### PR TITLE
include parsing errors

### DIFF
--- a/evaluate/eval.py
+++ b/evaluate/eval.py
@@ -83,6 +83,11 @@ class ConstError(Exception):
         self.errtype = "constants"
         self.base_message = f"constants mismatch between {str(l_term)} and {str(o_term)}"
 
+class ParsingError(Exception):
+    def __init__(self):
+        self.errtype = "format"
+        self.base_message = f"Couldn't parse the program."
+
 
 
 def check_bind(match, l_term, o_term):
@@ -325,7 +330,7 @@ def eval(output, label):
         out_prog = parse_text(output)
     except ParseError as e:
         print('ParseError:', e)
-        return None
+        return [ParsingError()]
 
     # check predicates
     errors = check_signatures(out_prog)
@@ -335,7 +340,8 @@ def eval(output, label):
         lab_prog = parse_text(label)
     except ParseError as e:
         print('ParseError:', e)
-        return None
+        return errors.append(ParsingError())
+
     matching, matching_errors = compare(out_prog, lab_prog)
     errors.extend(matching_errors)
 

--- a/evaluate/eval.py
+++ b/evaluate/eval.py
@@ -401,3 +401,5 @@ if __name__ == '__main__':
     else:
         errors = compare_files(args.pred, args.gold)
     print(errors)
+    missing_errors = Counter([e.args[0].split("(",1)[0] for e in errors[0]["missing"]])
+    print(f"Missing errors breakdown: {missing_errors}")

--- a/run/run.sh
+++ b/run/run.sh
@@ -9,7 +9,9 @@
 
 #PATH_TO_OLD="/mnt/D2D6AD4FD6AD349F/Users/pietr/Desktop/PhD/nlp4plp_old/code/solver/run_solver.pl"
 SOLVER_PATH="../solver/solver.pl"
-DATA="../compressed"
+#DATA="../compressed"
+#DATA="/mnt/b5320167-5dbd-4498-bf34-173ac5338c8d/Datasets/nlp4plp/compressed"
+DATA="/mnt/b5320167-5dbd-4498-bf34-173ac5338c8d/Datasets/nlp4plp/examples"
 
 # A POSIX variable
 OPTIND=1


### PR DESCRIPTION
I get a ParseError when eval.py returns None.
```
ParseError: Unmatched character '(' at 5:6.
Traceback (most recent call last):
  File "../eval.py", line 394, in <module>
    errors = compare_folders(args.pred, args.gold)
  File "../eval.py", line 383, in compare_folders
    errors += eval(o, l)
TypeError: 'NoneType' object is not iterable
```
I include a fix to include the parsing error as just another instance of an error we can get statistics from. Of course when this error happens, the program can't be correctly represented and other error types can't be collected.